### PR TITLE
Added a button in Alfresco Share to open documents readonly with onlyoffice

### DIFF
--- a/repo/src/main/java/com/parashift/onlyoffice/Prepare.java
+++ b/repo/src/main/java/com/parashift/onlyoffice/Prepare.java
@@ -71,13 +71,6 @@ public class Prepare extends AbstractWebScript {
         mesService.registerResourceBundle("alfresco/messages/prepare");
         if (request.getParameter("nodeRef") != null) {
             boolean isReadOnly = request.getParameter("readonly") != null;
-            /*
-            String[] parameters = request.getParameterNames();
-            String output = "isReadOnly = " + isReadOnly + "\n";
-            for(int i=0;i<parameters.length;i++)
-                output += parameters[i] + "\n";
-            throw new WebScriptException(output);
-*/
 
             String newFileMime = request.getParameter("new");
             NodeRef nodeRef = new NodeRef(request.getParameter("nodeRef"));

--- a/repo/src/main/java/com/parashift/onlyoffice/Prepare.java
+++ b/repo/src/main/java/com/parashift/onlyoffice/Prepare.java
@@ -70,6 +70,14 @@ public class Prepare extends AbstractWebScript {
     public void execute(WebScriptRequest request, WebScriptResponse response) throws IOException {
         mesService.registerResourceBundle("alfresco/messages/prepare");
         if (request.getParameter("nodeRef") != null) {
+            boolean isReadOnly = request.getParameter("readonly") != null;
+            /*
+            String[] parameters = request.getParameterNames();
+            String output = "isReadOnly = " + isReadOnly + "\n";
+            for(int i=0;i<parameters.length;i++)
+                output += parameters[i] + "\n";
+            throw new WebScriptException(output);
+*/
 
             String newFileMime = request.getParameter("new");
             NodeRef nodeRef = new NodeRef(request.getParameter("nodeRef"));
@@ -150,9 +158,15 @@ public class Prepare extends AbstractWebScript {
 
                 responseJson.put("editorConfig", editorConfigObject);
                 editorConfigObject.put("lang", mesService.getLocale().toLanguageTag());
-                editorConfigObject.put("mode", "edit");
+
+                if(isReadOnly)
+                    editorConfigObject.put("mode", "view");
+                else
+                    editorConfigObject.put("mode", "edit");
+
                 editorConfigObject.put("callbackUrl", callbackUrl);
                 editorConfigObject.put("user", userObject);
+
                 userObject.put("id", username);
 
                 if (personInfo == null) {

--- a/share/src/main/resources/alfresco/messages/onlyoffice.properties
+++ b/share/src/main/resources/alfresco/messages/onlyoffice.properties
@@ -4,5 +4,6 @@ actions.document.onlyoffice-create-docx=Create new Text Document
 actions.document.onlyoffice-create-pptx=Create new Presentation
 actions.document.onlyoffice-create-xlsx=Create new Cell Document
 actions.document.onlyoffice-edit=Edit in ONLYOFFICE
+actions.document.onlyoffice-read=Read in ONLYOFFICE
 alfresco.document.onlyoffice.action.convert.msg.failure=Could not convert '{0}'
 alfresco.document.onlyoffice.action.convert.msg.success='{0}' was successfully converted

--- a/share/src/main/resources/alfresco/messages/onlyoffice_de.properties
+++ b/share/src/main/resources/alfresco/messages/onlyoffice_de.properties
@@ -4,5 +4,6 @@ actions.document.onlyoffice-create-docx=Neues Textdokument erstellen
 actions.document.onlyoffice-create-pptx=Neue Pr\u00E4sentation erstellen
 actions.document.onlyoffice-create-xlsx=Neue Kalkulationstabelle erstellen
 actions.document.onlyoffice-edit=Mit ONLYOFFICE bearbeiten
+actions.document.onlyoffice-read=Mit ONLYOFFICE lesen
 alfresco.document.onlyoffice.action.convert.msg.failure='{0}' konnte nicht konvertiert werden
 alfresco.document.onlyoffice.action.convert.msg.success='{0}' wurde erfolgreich konvertiert

--- a/share/src/main/resources/alfresco/messages/onlyoffice_es.properties
+++ b/share/src/main/resources/alfresco/messages/onlyoffice_es.properties
@@ -3,6 +3,6 @@ actions.document.onlyoffice-convert=Convierta usando ONLYOFFICE
 actions.document.onlyoffice-create-docx=Cree nuevo documento de texto
 actions.document.onlyoffice-create-pptx=Cree nueva presentaci\u00F3n
 actions.document.onlyoffice-create-xlsx=Cree nuevo documento de celdas
-actions.document.onlyoffice-edit=Editar en ONLYOFFICE
+actions.document.onlyoffice-edit=Leer en ONLYOFFICE
 alfresco.document.onlyoffice.action.convert.msg.failure=No se pudo convertir '{0}'
 alfresco.document.onlyoffice.action.convert.msg.success='{0}' fue exitosamente convertido

--- a/share/src/main/resources/alfresco/messages/onlyoffice_fr.properties
+++ b/share/src/main/resources/alfresco/messages/onlyoffice_fr.properties
@@ -4,5 +4,6 @@ actions.document.onlyoffice-create-docx=Cr\u00E9er un nouveau document texte
 actions.document.onlyoffice-create-pptx=Cr\u00E9er une nouvelle pr\u00E9sentation
 actions.document.onlyoffice-create-xlsx=Cr\u00E9er une nouvelle feuille de calcul
 actions.document.onlyoffice-edit=Modifier dans ONLYOFFICE
+actions.document.onlyoffice-read=Lire dans ONLYOFFICE
 alfresco.document.onlyoffice.action.convert.msg.failure=Impossible de convertir '{0}'
 alfresco.document.onlyoffice.action.convert.msg.success='{0}' a \u00E9t\u00E9 converti avec succ\u00E8s

--- a/share/src/main/resources/alfresco/messages/onlyoffice_it.properties
+++ b/share/src/main/resources/alfresco/messages/onlyoffice_it.properties
@@ -4,5 +4,6 @@ actions.document.onlyoffice-create-docx=Crea nuovo Documento di testo
 actions.document.onlyoffice-create-pptx=Crea nuova Presentazione
 actions.document.onlyoffice-create-xlsx=Crea nuovo Foglio di calcolo
 actions.document.onlyoffice-edit=Modifica in ONLYOFFICE
+actions.document.onlyoffice-read=Leggere in ONLYOFFICE
 alfresco.document.onlyoffice.action.convert.msg.failure=Impossibile convertire '{0}'
 alfresco.document.onlyoffice.action.convert.msg.success='{0}' \u00E8 stato convertito con successo

--- a/share/src/main/resources/alfresco/onlyoffice-config.xml
+++ b/share/src/main/resources/alfresco/onlyoffice-config.xml
@@ -11,13 +11,24 @@
                     <permission allow="true">Write</permission>
                 </permissions>
             </action>
+            <action id="document-onlyoffice-read" type="link" label="actions.document.onlyoffice-read">
+                <param name="href">onlyoffice-edit?readonly=1&amp;nodeRef={node.nodeRef}&amp;amp;new=</param>
+                <param name="target">_blank</param>
+                <evaluator>evaluator.doclib.action.onlyofficeEditMimetype</evaluator>
+                <!--<evaluator>evaluator.doclib.action.allowOnlyofficeEdit</evaluator>-->
+                <!--<permissions>
+                    <permission allow="true">Read</permission>
+                </permissions>-->
+            </action>
         </actions>
         <actionGroups>
             <actionGroup id="document-browse">
                 <action index="90" id="document-onlyoffice-edit" />
+                <action index="91" id="document-onlyoffice-read" />
             </actionGroup>
             <actionGroup id="document-details">
                 <action index="90" id="document-onlyoffice-edit" />
+                <action index="91" id="document-onlyoffice-read" />
             </actionGroup>
         </actionGroups>
     </config>

--- a/share/src/main/resources/alfresco/onlyoffice-config.xml
+++ b/share/src/main/resources/alfresco/onlyoffice-config.xml
@@ -15,10 +15,6 @@
                 <param name="href">onlyoffice-edit?readonly=1&amp;nodeRef={node.nodeRef}&amp;amp;new=</param>
                 <param name="target">_blank</param>
                 <evaluator>evaluator.doclib.action.onlyofficeEditMimetype</evaluator>
-                <!--<evaluator>evaluator.doclib.action.allowOnlyofficeEdit</evaluator>-->
-                <!--<permissions>
-                    <permission allow="true">Read</permission>
-                </permissions>-->
             </action>
         </actions>
         <actionGroups>

--- a/share/src/main/resources/alfresco/site-webscripts/com/parashift/onlyoffice-edit.get.js
+++ b/share/src/main/resources/alfresco/site-webscripts/com/parashift/onlyoffice-edit.get.js
@@ -3,7 +3,8 @@
     http://www.onlyoffice.com
 */
 
-pObj = eval('(' + remote.call("/parashift/onlyoffice/prepare?nodeRef=" + url.args.nodeRef + "&new=" + url.args.new) + ')');
+var readonly = url.args.readonly ? "readonly=1&" : "";
+pObj = eval('(' + remote.call("/parashift/onlyoffice/prepare?" + readonly + "nodeRef=" + url.args.nodeRef + "&new=" + url.args.new) + ')');
 model.onlyofficeUrl = pObj.onlyofficeUrl;
 model.docTitle = pObj.document.title;
 delete (pObj.onlyofficeUrl);


### PR DESCRIPTION
Hello,

I had the need to open documents in Onlyoffice in readonly mode, so I added this feature in the code.
Please excuse my lack of knowledge in Spring development, I tried to be as clean as possible :)

In case a document is not editable by the user, this new button will show up.
If the user can modify a document, both buttons (Edit in OO and Read in OO) will be available.

Cheers !
Nico