### PR TITLE
Fix for issue #32  Alfresco Modules Packages AMP for distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,6 @@
                     the layout of your AMP. The end result is that Maven will produce both a JAR file and an AMP with your
                     module.
                 -->
-                <!--
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
@@ -142,7 +141,6 @@
                         </dependency>
                     </dependencies>
                 </plugin>
-                -->
 
                 <!-- Filter resources in any sub-project with this config -->
                 <plugin>

--- a/repo/pom.xml
+++ b/repo/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.onlyoffice.alfresco</groupId>
         <artifactId>onlyoffice-integration</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2</version>
     </parent>
 
     <properties>

--- a/repo/src/main/assembly/amp.xml
+++ b/repo/src/main/assembly/amp.xml
@@ -1,0 +1,61 @@
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+
+    <!--
+    Note that the Module dependency specified in the configuration section for the Alfresco Maven Plugin
+    needs to be set to amp if any 3rd party libs should be applied by MMT:
+`
+    <platformModules>
+        <moduleDependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>some-platform-jar</artifactId>
+            <version>${project.version}</version>
+            <type>amp</type>
+        </moduleDependency>
+    -->
+
+    <id>build-amp-file</id>
+
+    <formats>
+        <format>amp</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <files>
+        <!-- Filter module.properties and put at top level in the AMP -->
+        <file>
+            <source>src/main/resources/alfresco/module/${project.artifactId}/module.properties</source>
+            <filtered>true</filtered>
+        </file>
+        <!-- Include AMP -> WAR mapping file (needed for custom mappings) -->
+        <file>
+            <source>src/main/assembly/file-mapping.properties</source>
+            <filtered>false</filtered>
+        </file>
+    </files>
+
+    <fileSets>
+        <!-- Anything in the assembly/web directory will end up in the /web directory in the AMP -->
+        <fileSet>
+            <directory>src/main/assembly/web</directory>
+            <outputDirectory>web</outputDirectory>
+            <filtered>true</filtered> <!-- Will filter files and substitute POM props such as for example ${project.name} -->
+            <excludes>
+                <exclude>README.md</exclude>
+            </excludes>
+        </fileSet>
+    </fileSets>
+
+    <!-- Include the project artifact (JAR) in the /lib directory in the AMP, and any 3rd party libraries (JARs)
+         used by the customization.
+    -->
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+        </dependencySet>
+    </dependencySets>
+
+</assembly>

--- a/repo/src/main/assembly/file-mapping.properties
+++ b/repo/src/main/assembly/file-mapping.properties
@@ -1,0 +1,27 @@
+# Custom AMP to WAR location mappings
+
+#
+# The following property can be used to include the standard set of mappings.
+# The contents of this file will override any defaults.  The default is
+# 'true', i.e. the default mappings will be augmented or modified by values in
+# this file.
+#
+# Default mappings are:
+#
+# /config=/WEB-INF/classes
+# /lib=/WEB-INF/lib
+# /licenses=/WEB-INF/licenses
+# /web/jsp=/jsp
+# /web/css=/css
+# /web/images=/images
+# /web/scripts=/scripts
+# /web/php=/php
+#
+include.default=true
+
+#
+# Custom mappings.  If 'include.default' is false, then this is the complete set.
+# Map /web to / in AMP so we can override things like favicon.ico
+#
+/web=/
+

--- a/repo/src/main/assembly/web/README.md
+++ b/repo/src/main/assembly/web/README.md
@@ -1,0 +1,22 @@
+# Web resources that should override out-of-the-box files
+
+Put here any web resources that should override out-of-the-box
+web resources, such as favicon.ico. They will then end up in the 
+*/web* directory in the AMP, and applied to the WAR, and override
+any existing web resources in the Alfresco.WAR.
+
+**Note**. Module dependency needs to be set to amp for the web resources to be applied by MMT:
+
+`
+<moduleDependency>
+    <groupId>${project.groupId}</groupId>
+    <artifactId>some-platform-jar</artifactId>
+    <version>${project.version}</version>
+    <type>amp</type>
+</moduleDependency>
+`
+   
+**Important**. New web resources should not be located here, but instead 
+               in the usual place in the *src/main/resources/META-INF/resources* directory.
+  
+ 

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.onlyoffice.alfresco</groupId>
         <artifactId>onlyoffice-integration</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2</version>
     </parent>
 
     <properties>

--- a/share/src/main/assembly/amp.xml
+++ b/share/src/main/assembly/amp.xml
@@ -1,0 +1,61 @@
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+
+    <!--
+    Note that the Module dependency specified in the configuration section for the Alfresco Maven Plugin
+    needs to be set to amp if any 3rd party libs should be applied by MMT:
+    `
+    <shareModules>
+        <moduleDependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>some-share-jar</artifactId>
+            <version>${project.version}</version>
+            <type>amp</type>
+        </moduleDependency>
+    -->
+
+    <id>build-amp-file</id>
+
+    <formats>
+        <format>amp</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <files>
+        <!-- Filter module.properties and put at top level in the AMP -->
+        <file>
+            <source>src/main/resources/alfresco/module/${project.artifactId}/module.properties</source>
+            <filtered>true</filtered>
+        </file>
+        <!-- Include AMP -> WAR mapping file (needed for custom mappings) -->
+        <file>
+            <source>src/main/assembly/file-mapping.properties</source>
+            <filtered>false</filtered>
+        </file>
+    </files>
+
+    <fileSets>
+        <!-- Anything in the assembly/web directory will end up in the /web directory in the AMP -->
+        <fileSet>
+            <directory>src/main/assembly/web</directory>
+            <outputDirectory>web</outputDirectory>
+            <filtered>true</filtered> <!-- Will filter files and substitute POM props such as for example ${project.name} -->
+            <excludes>
+                <exclude>README.md</exclude>
+            </excludes>
+        </fileSet>
+    </fileSets>
+
+    <!-- Include the project artifact (JAR) in the /lib directory in the AMP, and any 3rd party libraries (JARs)
+         used by the customization.
+    -->
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+        </dependencySet>
+    </dependencySets>
+
+</assembly>

--- a/share/src/main/assembly/file-mapping.properties
+++ b/share/src/main/assembly/file-mapping.properties
@@ -1,0 +1,27 @@
+# Custom AMP to WAR location mappings
+
+#
+# The following property can be used to include the standard set of mappings.
+# The contents of this file will override any defaults.  The default is
+# 'true', i.e. the default mappings will be augmented or modified by values in
+# this file.
+#
+# Default mappings are:
+#
+# /config=/WEB-INF/classes
+# /lib=/WEB-INF/lib
+# /licenses=/WEB-INF/licenses
+# /web/jsp=/jsp
+# /web/css=/css
+# /web/images=/images
+# /web/scripts=/scripts
+# /web/php=/php
+#
+include.default=true
+
+#
+# Custom mappings.  If 'include.default' is false, then this is the complete set.
+# Map /web to / in AMP so we can override things like favicon.ico
+#
+/web=/
+

--- a/share/src/main/assembly/web/README.md
+++ b/share/src/main/assembly/web/README.md
@@ -1,0 +1,22 @@
+# Web resources that should override out-of-the-box files
+
+Put here any web resources that should override out-of-the-box
+web resources, such as favicon.ico. They will then end up in the 
+*/web* directory in the AMP, and applied to the WAR, and override
+any existing web resources in the Share.WAR.
+
+**Note**. Module dependency needs to be set to amp for the web resources to be applied by MMT:
+
+`
+<moduleDependency>
+    <groupId>${project.groupId}</groupId>
+    <artifactId>some-share-jar</artifactId>
+    <version>${project.version}</version>
+    <type>amp</type>
+</moduleDependency>
+`
+   
+**Important**. New web resources should not be located here, but instead 
+               in the usual place in the *src/main/resources/META-INF/resources/<module-id>/* directory.
+  
+ 


### PR DESCRIPTION
- Aligned the pom to the super pom version (4.0.2 and not 4.0.1)
- Uncommented the section in main pom about AMP generation
- Provided standard amp.xml

Thanks to Violeta Popescu <Violeta.Popescu@realdolmen.com> for her help on this.