### PR TITLE
Hotfix/4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 4.1.1
+## Fixed
+- Disallow editing when user has no write permissions [#35](https://github.com/ONLYOFFICE/onlyoffice-alfresco/issues/35)
+- disallow editing non OOXML files by removing readonly param
+
 ## 4.1.0
 ## Added
 - [Force saving](https://api.onlyoffice.com/editors/save#forcesave) for documents. Can be toggled on/off in settings [#23](https://github.com/ONLYOFFICE/onlyoffice-alfresco/issues/23)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.onlyoffice.alfresco</groupId>
     <artifactId>onlyoffice-integration</artifactId>
-    <version>4.1.0</version>
+    <version>4.1.1</version>
     <name>ONLYOFFICE Alfresco Integration</name>
     <description>This Module integrates Alfresco Share with ONLYOFFICE</description>
     <packaging>pom</packaging>

--- a/repo/pom.xml
+++ b/repo/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.onlyoffice.alfresco</groupId>
         <artifactId>onlyoffice-integration</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.1</version>
     </parent>
 
     <properties>

--- a/repo/src/main/java/com/parashift/onlyoffice/Prepare.java
+++ b/repo/src/main/java/com/parashift/onlyoffice/Prepare.java
@@ -30,7 +30,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Created by cetra on 20/10/15.
@@ -150,10 +152,14 @@ public class Prepare extends AbstractWebScript {
                     return;
                 }
 
+                String mimeType = mimetypeService.getMimetype(docExt);
+
                 responseJson.put("config", configJson);
                 responseJson.put("onlyofficeUrl", util.getEditorUrl());
-                responseJson.put("mime", mimetypeService.getMimetype(docExt));
+                responseJson.put("mime", mimeType);
                 responseJson.put("previewEnabled", preview);
+
+                boolean canWrite = isEditable(mimeType) && permissionService.hasPermission(nodeRef, PermissionService.WRITE) == AccessStatus.ALLOWED;
 
                 String contentUrl = util.getContentUrl(nodeRef);
                 String key = util.getKey(nodeRef);
@@ -179,7 +185,7 @@ public class Prepare extends AbstractWebScript {
 
                 configJson.put("editorConfig", editorConfigObject);
                 editorConfigObject.put("lang", mesService.getLocale().toLanguageTag());
-                if (isReadOnly || preview || permissionService.hasPermission(nodeRef, PermissionService.WRITE) == AccessStatus.DENIED) {
+                if (isReadOnly || preview || !canWrite) {
                     editorConfigObject.put("mode", "view");
                     permObject.put("edit", false);
                 } else {
@@ -216,6 +222,18 @@ public class Prepare extends AbstractWebScript {
                 throw new WebScriptException("Unable to create JWT token: " + ex.getMessage());
             }
         }
+    }
+
+    private static Set<String> EditableSet = new HashSet<String>() {{
+        add("text/plain");
+        add("text/csv");
+        add("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        add("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        add("application/vnd.openxmlformats-officedocument.presentationml.presentation");
+    }};
+
+    private boolean isEditable(String mime) {
+        return EditableSet.contains(mime);
     }
 
     private String getDocType(String ext) {

--- a/repo/src/main/java/com/parashift/onlyoffice/Prepare.java
+++ b/repo/src/main/java/com/parashift/onlyoffice/Prepare.java
@@ -6,6 +6,8 @@ import org.alfresco.service.cmr.repository.ContentWriter;
 import org.alfresco.service.cmr.repository.MimetypeService;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.security.AccessStatus;
+import org.alfresco.service.cmr.security.PermissionService;
 import org.alfresco.service.cmr.security.PersonService;
 import org.alfresco.service.cmr.security.PersonService.PersonInfo;
 import org.alfresco.service.cmr.version.VersionService;
@@ -63,6 +65,9 @@ public class Prepare extends AbstractWebScript {
 
     @Autowired
     VersionService versionService;
+
+    @Autowired
+    PermissionService permissionService;
 
     @Autowired
     JwtManager jwtManager;
@@ -174,7 +179,7 @@ public class Prepare extends AbstractWebScript {
 
                 configJson.put("editorConfig", editorConfigObject);
                 editorConfigObject.put("lang", mesService.getLocale().toLanguageTag());
-                if (isReadOnly || preview) {
+                if (isReadOnly || preview || permissionService.hasPermission(nodeRef, PermissionService.WRITE) == AccessStatus.DENIED) {
                     editorConfigObject.put("mode", "view");
                     permObject.put("edit", false);
                 } else {

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.onlyoffice.alfresco</groupId>
         <artifactId>onlyoffice-integration</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.1</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
## 4.1.1
## Fixed
- Disallow editing when user has no write permissions [#35](https://github.com/ONLYOFFICE/onlyoffice-alfresco/issues/35)
- disallow editing non OOXML files by removing readonly param