### PR TITLE
Fix startup error in new Alfresco install with onlyoffice-alfresco preinstalled

### DIFF
--- a/repo/src/main/java/com/parashift/onlyoffice/sdk/client/ApacheHttpclientDocumentServerClientImpl.java
+++ b/repo/src/main/java/com/parashift/onlyoffice/sdk/client/ApacheHttpclientDocumentServerClientImpl.java
@@ -67,7 +67,7 @@ public class ApacheHttpclientDocumentServerClientImpl extends AbstractDocumentSe
     private CloseableHttpClient httpClient;
     private CloseableHttpClient httpClientForSyncConvertRequest;
 
-    private String baseUrl;
+    private String baseUrl = null;
 
     private boolean isIgnoreSSLCertificate;
 
@@ -76,14 +76,14 @@ public class ApacheHttpclientDocumentServerClientImpl extends AbstractDocumentSe
     public ApacheHttpclientDocumentServerClientImpl(final DocumentServerClientSettings documentServerClientSettings) {
         super(documentServerClientSettings);
 
-        init();
+        // not safe to init() here - attribute service might not be ready yet
     }
 
     public ApacheHttpclientDocumentServerClientImpl(final SettingsManager settingsManager,
                                                     final UrlManager urlManager) {
         super(settingsManager, urlManager);
 
-        init();
+        // not safe to init() here - attribute service might not be ready yet
     }
 
     @Override
@@ -332,6 +332,10 @@ public class ApacheHttpclientDocumentServerClientImpl extends AbstractDocumentSe
     }
 
     protected boolean shouldReinit() {
+        if (baseUrl == null) {
+            return true;
+        }
+
         HttpClientProperties httpClientProperties = getHttpClientProperties();
 
         return this.isIgnoreSSLCertificate != httpClientProperties.getIgnoreSslCertificate()


### PR DESCRIPTION
When a brand new Alfresco install is being brought up for the first time, ApacheHttpclientDocumentServerClientImpl might get created before the database schema is initialized. Thus, it's not safe to call init() from the constructor, as it will access AttributeService before the attribute tables are ready in the database.

Instead, init ApacheHttpclientDocumentServerClientImpl lazily during its first use, which occurs long after the database schema is initialized.

Fixes the following error on Alfresco startup:
```
### Error querying database.  Cause: org.postgresql.util.PSQLException: ERROR: relation "alf_prop_class" does not exist
  Position: 47
### The error may exist in alfresco/ibatis/#resource.dialect#/propval-common-SqlMap.xml
### The error may involve alfresco.propval.select_PropertyClassByName-Inline
### The error occurred while setting parameters
### SQL: select             *         from             alf_prop_class         where             java_class_name_crc = ? and             java_class_name_short = ?
### Cause: org.postgresql.util.PSQLException: ERROR: relation "alf_prop_class" does not exist
  Position: 47
; bad SQL grammar []
    at org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator.doTranslate(SQLErrorCodeSQLExceptionTranslator.java:246) ~[spring-jdbc-6.1.14.jar:6.1.14]
    at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:107) ~[spring-jdbc-6.1.14.jar:6.1.14]
    at org.mybatis.spring.MyBatisExceptionTranslator.translateExceptionIfPossible(MyBatisExceptionTranslator.java:93) ~[mybatis-spring-3.0.4.jar:3.0.4]
    at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:347) ~[mybatis-spring-3.0.4.jar:3.0.4]
    at jdk.proxy3/jdk.proxy3.$Proxy28.selectOne(Unknown Source) ~[?:?]
    at org.mybatis.spring.SqlSessionTemplate.selectOne(SqlSessionTemplate.java:154) ~[mybatis-spring-3.0.4.jar:3.0.4]
    at org.alfresco.repo.domain.propval.ibatis.PropertyValueDAOImpl.findClassByValue(PropertyValueDAOImpl.java:145) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl$PropertyClassCallbackDAO.findByValue(AbstractPropertyValueDAOImpl.java:370) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl$PropertyClassCallbackDAO.findByValue(AbstractPropertyValueDAOImpl.java:1) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.cache.lookup.EntityLookupCache.getByValue(EntityLookupCache.java:393) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl.getPropertyClass(AbstractPropertyValueDAOImpl.java:320) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.ibatis.PropertyValueDAOImpl.findPropertyValueByValue(PropertyValueDAOImpl.java:350) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl$PropertyValueCallbackDAO.findByValue(AbstractPropertyValueDAOImpl.java:819) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl$PropertyValueCallbackDAO.findByValue(AbstractPropertyValueDAOImpl.java:1) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.cache.lookup.EntityLookupCache.getByValue(EntityLookupCache.java:393) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl.getPropertyValue(AbstractPropertyValueDAOImpl.java:737) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl.getPropertyUniqueContext(AbstractPropertyValueDAOImpl.java:1270) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.attributes.AttributeServiceImpl.getAttribute(AttributeServiceImpl.java:110) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at com.parashift.onlyoffice.sdk.manager.settings.SettingsManagerImpl.getSetting(SettingsManagerImpl.java:27) ~[onlyoffice-integration-platform-jar-8.2.0.jar:?]
    at com.onlyoffice.manager.settings.DefaultSettingsManager.isDemoActive(DefaultSettingsManager.java:224) ~[docs-integration-sdk-1.6.0.jar:?]
    at com.onlyoffice.manager.settings.DefaultSettingsManager.isIgnoreSSLCertificate(DefaultSettingsManager.java:187) ~[docs-integration-sdk-1.6.0.jar:?]
    at com.onlyoffice.client.AbstractDocumentServerClient.getHttpClientProperties(AbstractDocumentServerClient.java:162) ~[docs-integration-sdk-1.6.0.jar:?]
    at com.parashift.onlyoffice.sdk.client.ApacheHttpclientDocumentServerClientImpl.init(ApacheHttpclientDocumentServerClientImpl.java:309) ~[onlyoffice-integration-platform-jar-8.2.0.jar:?]
    at com.parashift.onlyoffice.sdk.client.ApacheHttpclientDocumentServerClientImpl.<init>(ApacheHttpclientDocumentServerClientImpl.java:81) ~[onlyoffice-integration-platform-jar-8.2.0.jar:?]
    at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
    at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[?:?]
    at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
    at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500) ~[?:?]
    at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481) ~[?:?]
    at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:208) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:117) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:315) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:306) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1375) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1212) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:562) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:522) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:337) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:335) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:200) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:254) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1443) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1353) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.resolveFieldValue(AutowiredAnnotationBeanPostProcessor.java:785) ~[spring-beans-6.1.14.jar:6.1.14]
    ... 61 more
Caused by: org.postgresql.util.PSQLException: ERROR: relation "alf_prop_class" does not exist
  Position: 47
    at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2733) ~[postgresql-42.7.4.jar:42.7.4]
    at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2420) ~[postgresql-42.7.4.jar:42.7.4]
    at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:372) ~[postgresql-42.7.4.jar:42.7.4]
    at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:517) ~[postgresql-42.7.4.jar:42.7.4]
    at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:434) ~[postgresql-42.7.4.jar:42.7.4]
    at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:194) ~[postgresql-42.7.4.jar:42.7.4]
    at org.postgresql.jdbc.PgPreparedStatement.execute(PgPreparedStatement.java:180) ~[postgresql-42.7.4.jar:42.7.4]
    at org.apache.commons.dbcp2.DelegatingPreparedStatement.execute(DelegatingPreparedStatement.java:95) ~[commons-dbcp2-2.12.0.jar:2.12.0]
    at org.apache.commons.dbcp2.DelegatingPreparedStatement.execute(DelegatingPreparedStatement.java:95) ~[commons-dbcp2-2.12.0.jar:2.12.0]
    at org.apache.commons.dbcp2.DelegatingPreparedStatement.execute(DelegatingPreparedStatement.java:95) ~[commons-dbcp2-2.12.0.jar:2.12.0]
    at org.apache.ibatis.executor.statement.PreparedStatementHandler.query(PreparedStatementHandler.java:65) ~[mybatis-3.5.16.jar:3.5.16]
    at org.apache.ibatis.executor.statement.RoutingStatementHandler.query(RoutingStatementHandler.java:80) ~[mybatis-3.5.16.jar:3.5.16]
    at org.apache.ibatis.executor.SimpleExecutor.doQuery(SimpleExecutor.java:65) ~[mybatis-3.5.16.jar:3.5.16]
    at org.apache.ibatis.executor.BaseExecutor.queryFromDatabase(BaseExecutor.java:336) ~[mybatis-3.5.16.jar:3.5.16]
    at org.apache.ibatis.executor.BaseExecutor.query(BaseExecutor.java:158) ~[mybatis-3.5.16.jar:3.5.16]
    at org.apache.ibatis.executor.CachingExecutor.query(CachingExecutor.java:110) ~[mybatis-3.5.16.jar:3.5.16]
    at org.apache.ibatis.executor.CachingExecutor.query(CachingExecutor.java:90) ~[mybatis-3.5.16.jar:3.5.16]
    at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:154) ~[mybatis-3.5.16.jar:3.5.16]
    at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:147) ~[mybatis-3.5.16.jar:3.5.16]
    at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:142) ~[mybatis-3.5.16.jar:3.5.16]
    at org.apache.ibatis.session.defaults.DefaultSqlSession.selectOne(DefaultSqlSession.java:75) ~[mybatis-3.5.16.jar:3.5.16]
    at org.alfresco.ibatis.SqlSessionMetricsWrapper.selectOne(SqlSessionMetricsWrapper.java:104) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
    at java.base/java.lang.reflect.Method.invoke(Method.java:569) ~[?:?]
    at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:333) ~[mybatis-spring-3.0.4.jar:3.0.4]
    at jdk.proxy3/jdk.proxy3.$Proxy28.selectOne(Unknown Source) ~[?:?]
    at org.mybatis.spring.SqlSessionTemplate.selectOne(SqlSessionTemplate.java:154) ~[mybatis-spring-3.0.4.jar:3.0.4]
    at org.alfresco.repo.domain.propval.ibatis.PropertyValueDAOImpl.findClassByValue(PropertyValueDAOImpl.java:145) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl$PropertyClassCallbackDAO.findByValue(AbstractPropertyValueDAOImpl.java:370) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl$PropertyClassCallbackDAO.findByValue(AbstractPropertyValueDAOImpl.java:1) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.cache.lookup.EntityLookupCache.getByValue(EntityLookupCache.java:393) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl.getPropertyClass(AbstractPropertyValueDAOImpl.java:320) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.ibatis.PropertyValueDAOImpl.findPropertyValueByValue(PropertyValueDAOImpl.java:350) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl$PropertyValueCallbackDAO.findByValue(AbstractPropertyValueDAOImpl.java:819) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl$PropertyValueCallbackDAO.findByValue(AbstractPropertyValueDAOImpl.java:1) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.cache.lookup.EntityLookupCache.getByValue(EntityLookupCache.java:393) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl.getPropertyValue(AbstractPropertyValueDAOImpl.java:737) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.domain.propval.AbstractPropertyValueDAOImpl.getPropertyUniqueContext(AbstractPropertyValueDAOImpl.java:1270) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at org.alfresco.repo.attributes.AttributeServiceImpl.getAttribute(AttributeServiceImpl.java:110) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
    at com.parashift.onlyoffice.sdk.manager.settings.SettingsManagerImpl.getSetting(SettingsManagerImpl.java:27) ~[onlyoffice-integration-platform-jar-8.2.0.jar:?]
    at com.onlyoffice.manager.settings.DefaultSettingsManager.isDemoActive(DefaultSettingsManager.java:224) ~[docs-integration-sdk-1.6.0.jar:?]
    at com.onlyoffice.manager.settings.DefaultSettingsManager.isIgnoreSSLCertificate(DefaultSettingsManager.java:187) ~[docs-integration-sdk-1.6.0.jar:?]
    at com.onlyoffice.client.AbstractDocumentServerClient.getHttpClientProperties(AbstractDocumentServerClient.java:162) ~[docs-integration-sdk-1.6.0.jar:?]
    at com.parashift.onlyoffice.sdk.client.ApacheHttpclientDocumentServerClientImpl.init(ApacheHttpclientDocumentServerClientImpl.java:309) ~[onlyoffice-integration-platform-jar-8.2.0.jar:?]
    at com.parashift.onlyoffice.sdk.client.ApacheHttpclientDocumentServerClientImpl.<init>(ApacheHttpclientDocumentServerClientImpl.java:81) ~[onlyoffice-integration-platform-jar-8.2.0.jar:?]
    at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
    at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[?:?]
    at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
    at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500) ~[?:?]
    at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481) ~[?:?]
    at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:208) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:117) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:315) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:306) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1375) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1212) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:562) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:522) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:337) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:335) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:200) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:254) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1443) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1353) ~[spring-beans-6.1.14.jar:6.1.14]
    at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.resolveFieldValue(AutowiredAnnotationBeanPostProcessor.java:785) ~[spring-beans-6.1.14.jar:6.1.14]
    ... 61 more
11-Dec-2025 10:58:18.814 SEVERE [main] org.apache.catalina.core.StandardContext.startInternal One or more listeners failed to start. Full details will be found in the appropriate container log file
11-Dec-2025 10:58:18.814 SEVERE [main] org.apache.catalina.core.StandardContext.startInternal Context [/alfresco] startup failed due to previous errors
```