### PR TITLE
fix: defer DocumentServerClient initialization until Alfresco schema …

### DIFF
--- a/repo/src/main/java/com/parashift/onlyoffice/sdk/client/ApacheHttpclientDocumentServerClientImpl.java
+++ b/repo/src/main/java/com/parashift/onlyoffice/sdk/client/ApacheHttpclientDocumentServerClientImpl.java
@@ -75,15 +75,11 @@ public class ApacheHttpclientDocumentServerClientImpl extends AbstractDocumentSe
 
     public ApacheHttpclientDocumentServerClientImpl(final DocumentServerClientSettings documentServerClientSettings) {
         super(documentServerClientSettings);
-
-        init();
     }
 
     public ApacheHttpclientDocumentServerClientImpl(final SettingsManager settingsManager,
                                                     final UrlManager urlManager) {
         super(settingsManager, urlManager);
-
-        init();
     }
 
     @Override
@@ -332,6 +328,10 @@ public class ApacheHttpclientDocumentServerClientImpl extends AbstractDocumentSe
     }
 
     protected boolean shouldReinit() {
+        if (this.httpClient == null || this.httpClientForSyncConvertRequest == null) {
+            return true;
+        }
+
         HttpClientProperties httpClientProperties = getHttpClientProperties();
 
         return this.isIgnoreSSLCertificate != httpClientProperties.getIgnoreSslCertificate()

--- a/repo/src/main/java/com/parashift/onlyoffice/sdk/manager/settings/SettingsManagerImpl.java
+++ b/repo/src/main/java/com/parashift/onlyoffice/sdk/manager/settings/SettingsManagerImpl.java
@@ -24,7 +24,13 @@ public class SettingsManagerImpl extends DefaultSettingsManager {
 
     @Override
     public String getSetting(final String name) {
-        Object value = attributeService.getAttribute(SETTINGS_PREFIX + name);
+        Object value = null;
+
+        try {
+            value = attributeService.getAttribute(SETTINGS_PREFIX + name);
+        } catch (RuntimeException e) {
+            // AttributeService may not be ready during early Spring context bootstrap
+        }
 
         if (value == null) {
             value = globalProp.get(SETTINGS_PREFIX + name);

--- a/repo/src/main/resources/alfresco/extension/onlyoffice-context.xml
+++ b/repo/src/main/resources/alfresco/extension/onlyoffice-context.xml
@@ -34,7 +34,8 @@
     </bean>
 
     <bean id="onlyoffice-sdk-document-server-client"
-          class="com.parashift.onlyoffice.sdk.client.ApacheHttpclientDocumentServerClientImpl">
+          class="com.parashift.onlyoffice.sdk.client.ApacheHttpclientDocumentServerClientImpl"
+          lazy-init="true">
         <constructor-arg name="settingsManager" ref="onlyoffice-sdk-settings-manager"/>
         <constructor-arg name="urlManager" ref="onlyoffice-sdk-url-manager"/>
     </bean>


### PR DESCRIPTION
…is ready

## Summary

Fixes repository startup failure on Alfresco 25.3 when the ONLYOFFICE integration module is deployed.

The `onlyoffice-sdk-document-server-client` bean was initialized eagerly during Spring context bootstrap. Its constructor called `init()`, which accessed `SettingsManager` → `AttributeService` → PostgreSQL before Alfresco schema bootstrap had created tables such as `alf_prop_class`.

This PR defers HTTP client initialization and makes settings lookup tolerant of early bootstrap timing.

Fixes #224

## Changes

### `ApacheHttpclientDocumentServerClientImpl`
- Removed eager `init()` calls from constructors.
- Updated `shouldReinit()` to initialize when `httpClient` / `httpClientForSyncConvertRequest` are still `null`.
- HTTP client is now created on first use via the existing `prepareHttpClient()` flow.

### `SettingsManagerImpl`
- Wrapped `attributeService.getAttribute()` in a `try/catch` and fall back to `global-properties` when `AttributeService` is not ready during early Spring bootstrap.

### `onlyoffice-context.xml`
- Added `lazy-init="true"` to the `onlyoffice-sdk-document-server-client` bean to avoid eager instantiation during context startup.

## Why this works

By the time ONLYOFFICE actually needs the HTTP client (editor, callback, conversion, etc.), Alfresco schema bootstrap has completed and `AttributeService` can safely access the database.

## Test plan

- [x] Deploy module 8.3.0 on Alfresco ACS CE **25.3.0** with PostgreSQL
- [x] Start Alfresco with a **fresh** database volume
- [x] Verify repository starts without `alf_prop_class does not exist` errors
- [x] Verify module is loaded: `Starting module 'onlyoffice-integration-platform-jar' version 8.3.0`
- [ ] Open a supported document in Share and verify ONLYOFFICE editor loads
- [ ] Edit and save a document; verify callback is processed
- [ ] Verify settings can still be read from Admin Console / `onlyoffice-config` after startup
- [ ] Regression test on Alfresco 7.4.x (if applicable)