### PR TITLE
fix: pass fileId when converting document on save callback

### DIFF
--- a/repo/src/main/java/com/parashift/onlyoffice/sdk/service/CallbackServiceImpl.java
+++ b/repo/src/main/java/com/parashift/onlyoffice/sdk/service/CallbackServiceImpl.java
@@ -226,7 +226,7 @@ public class CallbackServiceImpl extends DefaultCallbackService {
             String fileUrl = callback.getUrl();
 
             if (!currentFileType.equals(callback.getFiletype())) {
-                fileUrl = convert(fileUrl, currentFileType);
+                fileUrl = convert(fileUrl, currentFileType, fileId);
             }
 
             editorLockManager.unlockFromEditor(nodeRef);
@@ -335,7 +335,7 @@ public class CallbackServiceImpl extends DefaultCallbackService {
             String fileUrl = callback.getUrl();
 
             if (!currentFileType.equals(callback.getFiletype())) {
-                fileUrl = convert(fileUrl, currentFileType);
+                fileUrl = convert(fileUrl, currentFileType, fileId);
             }
 
             Map<QName, Serializable> aspectEditingProperties = editorLockManager.getEditorLockProperties(nodeRef);
@@ -376,14 +376,14 @@ public class CallbackServiceImpl extends DefaultCallbackService {
         }
     }
 
-    private String convert(final String fileUrl, final String outputType) {
+    private String convert(final String fileUrl, final String outputType, final String fileId) {
         try {
             ConvertRequest convert = ConvertRequest.builder()
                     .outputtype(outputType)
                     .url(fileUrl)
                     .build();
 
-            ConvertResponse convertResponse = convertService.processConvert(convert, null);
+            ConvertResponse convertResponse = convertService.processConvert(convert, fileId);
 
             return convertResponse.getFileUrl();
         } catch (Exception e) {


### PR DESCRIPTION
When saving a PDF (or any document whose callback filetype differs from
the original extension), the connector reconverts the file via
ConvertService. processConvert() was called with a null fileId, causing
a NullPointerException in DocumentManagerImpl.getDocumentName().

Because the exception is thrown before unlockFromEditor() runs, the
document remained locked for further editing after a failed save.